### PR TITLE
Add sample agent-based laboratory dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8501
+
+CMD ["python", "-m", "streamlit", "run", "dashboard/app.py", "--server.address", "0.0.0.0", "--server.port", "8501"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: install test demo run-ui
+
+install:
+	python -m pip install -r requirements.txt
+
+test:
+	python -m pytest -q
+
+demo:
+	python demo_run.py
+
+run-ui:
+	python -m streamlit run dashboard/app.py

--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
-- 👋 Hi, I’m @Jags8-T
-- 👀 I’m interested in Trending technologies and tools
-- 🌱 I’m currently learning AI/Gen AI
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
+# Laboratory Dashboard Demo
 
-<!---
-Jags8-T/Jags8-T is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+This repository contains a minimal example of an agent-based laboratory dashboard.
+
+## Components
+- `agents/data_ingestion.py`: utilities for loading lab results. Besides
+  built-in sample data it can read from CSV files or any database that exposes
+  a Python DB-API connection.
+- `agents/analytics.py`: computes simple analytics such as pass rate.
+- `dashboard/app.py`: a small [Streamlit](https://streamlit.io) application
+  demonstrating the dashboard UI with selectable data sources.
+
+## Running the Dashboard
+Install the required dependency:
+
+```bash
+pip install streamlit
+```
+
+Then launch the dashboard:
+
+```bash
+streamlit run dashboard/app.py
+```
+
+The app will display sample lab results by default. Use the sidebar to load
+results from a CSV file or a SQLite database. The chat section remains a
+placeholder for future LLM-powered agents.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,73 @@
-# Laboratory Dashboard Demo
+# AI Laboratory Dashboard (Agentic Demo)
 
-This repository contains a minimal example of an agent-based laboratory dashboard.
+This repository provides an **immediate-demo, production-style prototype** of an
+agentic laboratory dashboard. It is designed to show how ingestion agents,
+analytics agents, and an operations copilot can work together in one interface.
 
-## Components
-- `agents/data_ingestion.py`: utilities for loading lab results. Besides
-  built-in sample data it can read from CSV files or any database that exposes
-  a Python DB-API connection.
-- `agents/analytics.py`: computes simple analytics such as pass rate.
-- `agents/chat_agent.py`: lightweight rule-based chat agent able to answer
-  simple questions about the loaded results.
-- `dashboard/app.py`: a small [Streamlit](https://streamlit.io) application
-  demonstrating the dashboard UI with selectable data sources and a chat pane
-  backed by the local chat agent.
+## What is included
 
-## Running the Dashboard
-Install the required dependency:
+- **Ingestion Agent (`agents/data_ingestion.py`)**
+  - Normalizes records into a strict `LabResult` contract.
+  - Supports multiple input systems:
+    - Built-in synthetic sample data
+    - CSV upload
+    - JSON upload
+    - SQL query over DB-API connection (e.g., SQLite)
+  - Supports multi-source merge for combined operational views.
+
+- **Analytics Agent (`agents/analytics.py`)**
+  - Dashboard KPIs (test count, pass/fail counts, pass rate, source count).
+  - Pass rate by test type.
+  - Daily volume trend.
+  - Rule-based alerts for high failure rates.
+
+- **Ops Copilot Agent (`agents/chat_agent.py`)**
+  - Deterministic, no external LLM required.
+  - Handles common lab manager prompts:
+    - KPI summary
+    - Overall and per-test pass rate
+    - Daily volume trend
+    - Failing sample list
+
+- **Streamlit Command Center (`dashboard/app.py`)**
+  - Multi-mode source connections.
+  - KPI cards + alert panel.
+  - Overview charts and records table.
+  - Embedded operations copilot pane.
+
+## Quick start
 
 ```bash
 pip install streamlit
-```
-
-Then launch the dashboard:
-
-```bash
 streamlit run dashboard/app.py
 ```
 
-The app will display sample lab results by default. Use the sidebar to load
-results from a CSV file or a SQLite database. The chat section uses a simple
-rule-based agent that can report the overall pass rate or list all sample
-results.
+Open the local Streamlit URL and start in **Sample** mode for an instant demo.
+
+## Suggested live demo flow (5 minutes)
+
+1. Launch dashboard in **Sample** mode and review KPI cards.
+2. Show **Monitoring Alerts** and explain threshold-based checks.
+3. Open **Overview** tab to review pass rate by test + daily volume trend.
+4. Open **Records** tab to show normalized fields (timestamp/system/technician).
+5. In **Ops Copilot**, ask:
+   - `Give KPI summary`
+   - `pass rate by test`
+   - `daily volume trend`
+   - `list failed samples`
+6. Switch to **CSV upload** or **JSON upload** to demonstrate connector agility.
+
+## Data contract
+
+Minimum required fields:
+- `sample_id`
+- `test_name`
+- `value`
+- `passed`
+
+Optional fields:
+- `measured_at` (ISO datetime preferred)
+- `source_system`
+- `technician`
+
+Missing timestamps default to current UTC for continuity.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ This repository contains a minimal example of an agent-based laboratory dashboar
   built-in sample data it can read from CSV files or any database that exposes
   a Python DB-API connection.
 - `agents/analytics.py`: computes simple analytics such as pass rate.
+- `agents/chat_agent.py`: lightweight rule-based chat agent able to answer
+  simple questions about the loaded results.
 - `dashboard/app.py`: a small [Streamlit](https://streamlit.io) application
-  demonstrating the dashboard UI with selectable data sources.
+  demonstrating the dashboard UI with selectable data sources and a chat pane
+  backed by the local chat agent.
 
 ## Running the Dashboard
 Install the required dependency:
@@ -24,5 +27,6 @@ streamlit run dashboard/app.py
 ```
 
 The app will display sample lab results by default. Use the sidebar to load
-results from a CSV file or a SQLite database. The chat section remains a
-placeholder for future LLM-powered agents.
+results from a CSV file or a SQLite database. The chat section uses a simple
+rule-based agent that can report the overall pass rate or list all sample
+results.

--- a/README.md
+++ b/README.md
@@ -1,65 +1,75 @@
 # AI Laboratory Dashboard (Agentic Demo)
 
 This repository provides an **immediate-demo, production-style prototype** of an
-agentic laboratory dashboard. It is designed to show how ingestion agents,
-analytics agents, and an operations copilot can work together in one interface.
+agentic laboratory dashboard. It shows how ingestion agents, analytics agents,
+and an operations copilot can work together in one interface.
 
 ## What is included
 
 - **Ingestion Agent (`agents/data_ingestion.py`)**
   - Normalizes records into a strict `LabResult` contract.
-  - Supports multiple input systems:
-    - Built-in synthetic sample data
-    - CSV upload
-    - JSON upload
-    - SQL query over DB-API connection (e.g., SQLite)
-  - Supports multi-source merge for combined operational views.
+  - Supports built-in sample data, CSV, JSON, SQL/DB-API, and multi-source merge.
 
 - **Analytics Agent (`agents/analytics.py`)**
-  - Dashboard KPIs (test count, pass/fail counts, pass rate, source count).
-  - Pass rate by test type.
-  - Daily volume trend.
-  - Rule-based alerts for high failure rates.
+  - Dashboard KPIs (test counts, pass/fail counts, pass rate, source count).
+  - Pass rate by test type, daily volume trend, and threshold alerts.
 
 - **Ops Copilot Agent (`agents/chat_agent.py`)**
-  - Deterministic, no external LLM required.
-  - Handles common lab manager prompts:
-    - KPI summary
-    - Overall and per-test pass rate
-    - Daily volume trend
-    - Failing sample list
+  - Deterministic responses (no external LLM required).
+  - Answers KPI summary, pass-rate questions, trend questions, failing sample lists.
 
 - **Streamlit Command Center (`dashboard/app.py`)**
   - Multi-mode source connections.
   - KPI cards + alert panel.
-  - Overview charts and records table.
-  - Embedded operations copilot pane.
+  - Overview charts + records table + embedded copilot.
+
+- **Demo Automation**
+  - `demo_run.py` prints a deterministic report for quick validation.
+  - `Makefile` shortcuts for install/test/demo/ui commands.
+  - `Dockerfile` for containerized one-command launch.
 
 ## Quick start
 
 ```bash
-pip install streamlit
-streamlit run dashboard/app.py
+python -m pip install -r requirements.txt
+python demo_run.py
+python -m streamlit run dashboard/app.py
 ```
 
-Open the local Streamlit URL and start in **Sample** mode for an instant demo.
+## One-command options
+
+```bash
+make install
+make test
+make demo
+make run-ui
+```
+
+## Docker demo
+
+```bash
+docker build -t lab-dashboard-demo .
+docker run --rm -p 8501:8501 lab-dashboard-demo
+```
+
+Then open `http://localhost:8501`.
 
 ## Suggested live demo flow (5 minutes)
 
-1. Launch dashboard in **Sample** mode and review KPI cards.
-2. Show **Monitoring Alerts** and explain threshold-based checks.
-3. Open **Overview** tab to review pass rate by test + daily volume trend.
-4. Open **Records** tab to show normalized fields (timestamp/system/technician).
+1. Run `python demo_run.py` to show deterministic KPI and copilot outputs.
+2. Launch UI and review KPI cards + monitoring alerts.
+3. In **Overview**, show pass-rate and daily trend charts.
+4. In **Records**, show normalized schema fields.
 5. In **Ops Copilot**, ask:
    - `Give KPI summary`
    - `pass rate by test`
    - `daily volume trend`
    - `list failed samples`
-6. Switch to **CSV upload** or **JSON upload** to demonstrate connector agility.
+6. Switch source mode to CSV/JSON/SQLite to demonstrate connector flexibility.
 
 ## Data contract
 
-Minimum required fields:
+Required fields:
 - `sample_id`
 - `test_name`
 - `value`

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,6 +1,7 @@
-"""Expose agents for analytics and data ingestion."""
+"""Expose agents used by the laboratory dashboard demo."""
 
 from . import analytics, data_ingestion
+from .chat_agent import ChatAgent
 
-__all__ = ["analytics", "data_ingestion"]
+__all__ = ["analytics", "data_ingestion", "ChatAgent"]
 

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Expose agents for analytics and data ingestion."""
+
+from . import analytics, data_ingestion
+
+__all__ = ["analytics", "data_ingestion"]
+

--- a/agents/analytics.py
+++ b/agents/analytics.py
@@ -1,25 +1,84 @@
 """Analytics agents for laboratory dashboard."""
 from __future__ import annotations
 
-from typing import Iterable
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
 
 from .data_ingestion import LabResult
 
 
+@dataclass(frozen=True)
+class DashboardMetrics:
+    total_tests: int
+    passed_tests: int
+    failed_tests: int
+    pass_rate: float
+    unique_samples: int
+    unique_systems: int
+
+
+
 def compute_pass_fail_rate(results: Iterable[LabResult]) -> float:
-    """Compute the pass rate for provided lab results.
-
-    Args:
-        results: An iterable of :class:`LabResult` instances.
-
-    Returns:
-        The fraction of tests that passed as a float between 0 and 1. If no
-        results are provided, ``0.0`` is returned.
-    """
-
     results = list(results)
     if not results:
         return 0.0
-
     passed = sum(1 for r in results if r.passed)
     return passed / len(results)
+
+
+
+def compute_dashboard_metrics(results: Iterable[LabResult]) -> DashboardMetrics:
+    rows = list(results)
+    total = len(rows)
+    passed = sum(1 for r in rows if r.passed)
+    failed = total - passed
+    return DashboardMetrics(
+        total_tests=total,
+        passed_tests=passed,
+        failed_tests=failed,
+        pass_rate=(passed / total) if total else 0.0,
+        unique_samples=len({r.sample_id for r in rows}),
+        unique_systems=len({r.source_system for r in rows}),
+    )
+
+
+
+def pass_rate_by_test(results: Iterable[LabResult]) -> Dict[str, float]:
+    grouped: Dict[str, List[LabResult]] = defaultdict(list)
+    for row in results:
+        grouped[row.test_name].append(row)
+    return {test_name: compute_pass_fail_rate(rows) for test_name, rows in grouped.items()}
+
+
+
+def daily_volume(results: Iterable[LabResult]) -> Dict[str, int]:
+    counts: Dict[str, int] = defaultdict(int)
+    for row in results:
+        counts[row.measured_at.date().isoformat()] += 1
+    return dict(sorted(counts.items()))
+
+
+
+def detect_alerts(results: Iterable[LabResult], fail_rate_threshold: float = 0.4) -> List[str]:
+    alerts: List[str] = []
+    rows = list(results)
+    if not rows:
+        return ["No records loaded. Connect a source to enable monitoring."]
+
+    metrics = compute_dashboard_metrics(rows)
+    overall_fail_rate = 1.0 - metrics.pass_rate
+    if overall_fail_rate > fail_rate_threshold:
+        alerts.append(
+            f"High failure rate detected ({overall_fail_rate:.0%}), above threshold {fail_rate_threshold:.0%}."
+        )
+
+    per_test = pass_rate_by_test(rows)
+    for test_name, rate in per_test.items():
+        if (1.0 - rate) > fail_rate_threshold:
+            alerts.append(f"{test_name} has elevated failures at {(1.0 - rate):.0%}.")
+
+    if not alerts:
+        alerts.append("All monitored KPIs are within expected thresholds.")
+
+    return alerts

--- a/agents/analytics.py
+++ b/agents/analytics.py
@@ -1,0 +1,25 @@
+"""Analytics agents for laboratory dashboard."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from .data_ingestion import LabResult
+
+
+def compute_pass_fail_rate(results: Iterable[LabResult]) -> float:
+    """Compute the pass rate for provided lab results.
+
+    Args:
+        results: An iterable of :class:`LabResult` instances.
+
+    Returns:
+        The fraction of tests that passed as a float between 0 and 1. If no
+        results are provided, ``0.0`` is returned.
+    """
+
+    results = list(results)
+    if not results:
+        return 0.0
+
+    passed = sum(1 for r in results if r.passed)
+    return passed / len(results)

--- a/agents/chat_agent.py
+++ b/agents/chat_agent.py
@@ -1,0 +1,48 @@
+"""Simple rule-based chat agent for the laboratory dashboard."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .data_ingestion import LabResult
+from .analytics import compute_pass_fail_rate
+
+
+class ChatAgent:
+    """Answer basic natural language questions about lab results.
+
+    The implementation is intentionally lightweight and deterministic so it can
+    run in limited environments without requiring external LLM services.
+    Currently it understands questions about overall pass rate and listing all
+    sample results.
+    """
+
+    def __init__(self, results: Iterable[LabResult]):
+        self.results: List[LabResult] = list(results)
+
+    def answer(self, query: str) -> str:
+        """Return a response for ``query``.
+
+        The matching is intentionally simple and based on lowercase keyword
+        checks to keep the demo self‑contained.
+        """
+
+        q = query.strip().lower()
+        if not self.results:
+            return "No data is currently loaded."
+
+        if "pass rate" in q:
+            rate = compute_pass_fail_rate(self.results)
+            return f"The pass rate is {rate:.0%}."
+
+        if "list" in q and "sample" in q:
+            lines = [
+                f"{r.sample_id} – {r.test_name}: {r.value} ({'PASS' if r.passed else 'FAIL'})"
+                for r in self.results
+            ]
+            return "\n".join(lines)
+
+        return (
+            "I can tell you the pass rate or list sample results. "
+            "Try asking 'What is the pass rate?'"
+        )
+

--- a/agents/chat_agent.py
+++ b/agents/chat_agent.py
@@ -1,48 +1,52 @@
-"""Simple rule-based chat agent for the laboratory dashboard."""
+"""Deterministic operations copilot for the laboratory dashboard."""
 from __future__ import annotations
 
 from typing import Iterable, List
 
+from .analytics import compute_dashboard_metrics, daily_volume, pass_rate_by_test
 from .data_ingestion import LabResult
-from .analytics import compute_pass_fail_rate
 
 
 class ChatAgent:
-    """Answer basic natural language questions about lab results.
-
-    The implementation is intentionally lightweight and deterministic so it can
-    run in limited environments without requiring external LLM services.
-    Currently it understands questions about overall pass rate and listing all
-    sample results.
-    """
+    """Answer practical operations questions from loaded lab results."""
 
     def __init__(self, results: Iterable[LabResult]):
         self.results: List[LabResult] = list(results)
 
     def answer(self, query: str) -> str:
-        """Return a response for ``query``.
-
-        The matching is intentionally simple and based on lowercase keyword
-        checks to keep the demo self‑contained.
-        """
-
         q = query.strip().lower()
         if not self.results:
-            return "No data is currently loaded."
+            return "No data is currently loaded. Connect CSV, JSON, or database data first."
+
+        metrics = compute_dashboard_metrics(self.results)
+
+        if any(token in q for token in ["summary", "kpi", "overview"]):
+            return (
+                f"Processed {metrics.total_tests} tests across {metrics.unique_samples} samples and "
+                f"{metrics.unique_systems} systems. Pass rate is {metrics.pass_rate:.0%}."
+            )
+
+        if "pass rate" in q and "test" in q:
+            per_test = pass_rate_by_test(self.results)
+            return "\n".join(f"{name}: {rate:.0%}" for name, rate in sorted(per_test.items()))
 
         if "pass rate" in q:
-            rate = compute_pass_fail_rate(self.results)
-            return f"The pass rate is {rate:.0%}."
+            return f"The overall pass rate is {metrics.pass_rate:.0%}."
 
-        if "list" in q and "sample" in q:
-            lines = [
-                f"{r.sample_id} – {r.test_name}: {r.value} ({'PASS' if r.passed else 'FAIL'})"
-                for r in self.results
-            ]
-            return "\n".join(lines)
+        if "volume" in q or "daily" in q or "trend" in q:
+            counts = daily_volume(self.results)
+            return "\n".join(f"{day}: {count} tests" for day, count in counts.items())
+
+        if "fail" in q and "sample" in q:
+            failed = [r for r in self.results if not r.passed]
+            if not failed:
+                return "No failing samples in the loaded dataset."
+            return "\n".join(
+                f"{r.sample_id} ({r.test_name}) from {r.source_system}"
+                for r in failed
+            )
 
         return (
-            "I can tell you the pass rate or list sample results. "
-            "Try asking 'What is the pass rate?'"
+            "I can provide KPI summary, overall/per-test pass rate, daily volume trend, "
+            "or list failing samples."
         )
-

--- a/agents/data_ingestion.py
+++ b/agents/data_ingestion.py
@@ -1,0 +1,96 @@
+"""Data ingestion agents for laboratory dashboard.
+
+This module provides utilities to simulate pulling data from laboratory
+instruments or LIMS systems. In a production environment these functions
+would connect to external services or databases. For this example we use
+static data to keep the code self‑contained.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, Any, List, Union
+import csv
+
+
+
+@dataclass
+class LabResult:
+    """Represents a single lab test result."""
+
+    sample_id: str
+    test_name: str
+    value: float
+    passed: bool
+
+
+def load_sample_results() -> List[LabResult]:
+    """Return a small list of sample lab results.
+
+    In a real deployment this function would pull records from a LIMS or
+    instrument API. Here we return a static list for demonstration and
+    testing purposes.
+    """
+
+    return [
+        LabResult(sample_id="S1", test_name="PCR", value=35.0, passed=True),
+        LabResult(sample_id="S2", test_name="PCR", value=40.2, passed=False),
+        LabResult(sample_id="S3", test_name="PCR", value=33.5, passed=True),
+        LabResult(sample_id="S4", test_name="PCR", value=38.1, passed=False),
+    ]
+
+
+def load_results_from_csv(source: Union[str, Path, IO[str]]) -> List[LabResult]:
+    """Load lab results from a CSV file or file-like object.
+
+    The CSV is expected to contain the columns ``sample_id``, ``test_name``,
+    ``value`` and ``passed``. The ``passed`` column may be ``1``/``0`` or any
+    case-insensitive representation of ``true``/``false``.
+    """
+
+    close_after = False
+    if hasattr(source, "read"):
+        fh = source  # type: ignore[assignment]
+    else:
+        fh = open(source, newline="")
+        close_after = True
+
+    try:
+        reader = csv.DictReader(fh)
+        results: List[LabResult] = []
+        for row in reader:
+            results.append(
+                LabResult(
+                    sample_id=row["sample_id"],
+                    test_name=row["test_name"],
+                    value=float(row["value"]),
+                    passed=str(row["passed"]).strip().lower() in {"1", "true", "yes", "pass"},
+                )
+            )
+        return results
+    finally:
+        if close_after:
+            fh.close()
+
+
+def load_results_from_db(conn: Any, query: str) -> List[LabResult]:
+    """Load lab results using an existing DB-API connection.
+
+    Args:
+        conn: An open database connection implementing the Python DB-API
+            (e.g. from ``sqlite3`` or ``psycopg2``).
+        query: SQL query returning ``sample_id``, ``test_name``, ``value`` and
+            ``passed`` columns.
+    """
+
+    cursor = conn.execute(query)
+    rows = cursor.fetchall()
+    return [
+        LabResult(
+            sample_id=row[0],
+            test_name=row[1],
+            value=float(row[2]),
+            passed=bool(row[3]),
+        )
+        for row in rows
+    ]

--- a/agents/data_ingestion.py
+++ b/agents/data_ingestion.py
@@ -1,51 +1,103 @@
-"""Data ingestion agents for laboratory dashboard.
+"""Data ingestion agents for the laboratory dashboard.
 
-This module provides utilities to simulate pulling data from laboratory
-instruments or LIMS systems. In a production environment these functions
-would connect to external services or databases. For this example we use
-static data to keep the code self‑contained.
+The helpers in this module focus on safe, explicit data normalization so the
+rest of the agentic pipeline can work with a consistent data contract.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, Any, List, Union
+from typing import IO, Any, Iterable, List, Mapping, Union
 import csv
+import json
 
 
+TRUTHY_VALUES = {"1", "true", "yes", "pass", "passed", "y"}
+FALSY_VALUES = {"0", "false", "no", "fail", "failed", "n"}
 
-@dataclass
+
+@dataclass(frozen=True)
 class LabResult:
-    """Represents a single lab test result."""
+    """Represents a normalized lab test result row."""
 
     sample_id: str
     test_name: str
     value: float
     passed: bool
+    measured_at: datetime
+    source_system: str
+    technician: str = "unknown"
+
+
+
+def _parse_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+
+    normalized = str(value).strip().lower()
+    if normalized in TRUTHY_VALUES:
+        return True
+    if normalized in FALSY_VALUES:
+        return False
+    raise ValueError(f"Unsupported boolean value: {value!r}")
+
+
+
+def _parse_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        dt = value
+    elif value in (None, ""):
+        dt = datetime.now(timezone.utc)
+    else:
+        text = str(value).strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        dt = datetime.fromisoformat(text)
+
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+
+def _normalize_record(record: Mapping[str, Any], default_source: str = "unknown") -> LabResult:
+    return LabResult(
+        sample_id=str(record["sample_id"]),
+        test_name=str(record["test_name"]),
+        value=float(record["value"]),
+        passed=_parse_bool(record["passed"]),
+        measured_at=_parse_datetime(record.get("measured_at")),
+        source_system=str(record.get("source_system") or default_source),
+        technician=str(record.get("technician") or "unknown"),
+    )
+
 
 
 def load_sample_results() -> List[LabResult]:
-    """Return a small list of sample lab results.
+    """Return realistic synthetic records for demo and tests."""
 
-    In a real deployment this function would pull records from a LIMS or
-    instrument API. Here we return a static list for demonstration and
-    testing purposes.
-    """
-
-    return [
-        LabResult(sample_id="S1", test_name="PCR", value=35.0, passed=True),
-        LabResult(sample_id="S2", test_name="PCR", value=40.2, passed=False),
-        LabResult(sample_id="S3", test_name="PCR", value=33.5, passed=True),
-        LabResult(sample_id="S4", test_name="PCR", value=38.1, passed=False),
+    rows = [
+        {"sample_id": "S-1001", "test_name": "PCR", "value": 32.1, "passed": True, "measured_at": "2026-03-31T08:05:00Z", "source_system": "LIMS-A", "technician": "A. Patel"},
+        {"sample_id": "S-1002", "test_name": "PCR", "value": 40.2, "passed": False, "measured_at": "2026-03-31T08:15:00Z", "source_system": "LIMS-A", "technician": "A. Patel"},
+        {"sample_id": "S-1003", "test_name": "CBC", "value": 5.6, "passed": True, "measured_at": "2026-04-01T09:10:00Z", "source_system": "Analyzer-X", "technician": "J. Kim"},
+        {"sample_id": "S-1004", "test_name": "CBC", "value": 3.8, "passed": False, "measured_at": "2026-04-01T09:25:00Z", "source_system": "Analyzer-X", "technician": "J. Kim"},
+        {"sample_id": "S-1005", "test_name": "Chem7", "value": 0.91, "passed": True, "measured_at": "2026-04-02T11:00:00Z", "source_system": "LIS-B", "technician": "M. Stone"},
+        {"sample_id": "S-1006", "test_name": "Chem7", "value": 1.22, "passed": False, "measured_at": "2026-04-02T11:20:00Z", "source_system": "LIS-B", "technician": "M. Stone"},
+        {"sample_id": "S-1007", "test_name": "PCR", "value": 34.4, "passed": True, "measured_at": "2026-04-03T10:00:00Z", "source_system": "LIMS-A", "technician": "T. Singh"},
+        {"sample_id": "S-1008", "test_name": "PCR", "value": 36.5, "passed": True, "measured_at": "2026-04-03T10:35:00Z", "source_system": "LIMS-A", "technician": "T. Singh"},
     ]
+    return [_normalize_record(row) for row in rows]
+
 
 
 def load_results_from_csv(source: Union[str, Path, IO[str]]) -> List[LabResult]:
     """Load lab results from a CSV file or file-like object.
 
-    The CSV is expected to contain the columns ``sample_id``, ``test_name``,
-    ``value`` and ``passed``. The ``passed`` column may be ``1``/``0`` or any
-    case-insensitive representation of ``true``/``false``.
+    Required columns: sample_id, test_name, value, passed.
+    Optional columns: measured_at, source_system, technician.
     """
 
     close_after = False
@@ -57,40 +109,62 @@ def load_results_from_csv(source: Union[str, Path, IO[str]]) -> List[LabResult]:
 
     try:
         reader = csv.DictReader(fh)
-        results: List[LabResult] = []
-        for row in reader:
-            results.append(
-                LabResult(
-                    sample_id=row["sample_id"],
-                    test_name=row["test_name"],
-                    value=float(row["value"]),
-                    passed=str(row["passed"]).strip().lower() in {"1", "true", "yes", "pass"},
-                )
-            )
-        return results
+        return [_normalize_record(row, default_source="csv") for row in reader]
     finally:
         if close_after:
             fh.close()
 
 
-def load_results_from_db(conn: Any, query: str) -> List[LabResult]:
+
+def load_results_from_json(source: Union[str, Path, IO[str]]) -> List[LabResult]:
+    """Load lab results from a JSON array."""
+
+    close_after = False
+    if hasattr(source, "read"):
+        fh = source  # type: ignore[assignment]
+    else:
+        fh = open(source)
+        close_after = True
+
+    try:
+        payload = json.load(fh)
+        if not isinstance(payload, list):
+            raise ValueError("JSON payload must be a list of result objects")
+        return [_normalize_record(row, default_source="json") for row in payload]
+    finally:
+        if close_after:
+            fh.close()
+
+
+
+def load_results_from_db(conn: Any, query: str, source_system: str = "database") -> List[LabResult]:
     """Load lab results using an existing DB-API connection.
 
-    Args:
-        conn: An open database connection implementing the Python DB-API
-            (e.g. from ``sqlite3`` or ``psycopg2``).
-        query: SQL query returning ``sample_id``, ``test_name``, ``value`` and
-            ``passed`` columns.
+    Query must return at least: sample_id, test_name, value, passed. It may also
+    return measured_at, source_system, technician in this exact order.
     """
 
-    cursor = conn.execute(query)
-    rows = cursor.fetchall()
-    return [
-        LabResult(
-            sample_id=row[0],
-            test_name=row[1],
-            value=float(row[2]),
-            passed=bool(row[3]),
-        )
-        for row in rows
-    ]
+    rows = conn.execute(query).fetchall()
+    results: List[LabResult] = []
+    for row in rows:
+        record = {
+            "sample_id": row[0],
+            "test_name": row[1],
+            "value": row[2],
+            "passed": row[3],
+            "measured_at": row[4] if len(row) > 4 else None,
+            "source_system": row[5] if len(row) > 5 else source_system,
+            "technician": row[6] if len(row) > 6 else "unknown",
+        }
+        results.append(_normalize_record(record, default_source=source_system))
+    return results
+
+
+
+def merge_results(*collections: Iterable[LabResult]) -> List[LabResult]:
+    """Merge multiple result collections and return in chronological order."""
+
+    merged: List[LabResult] = []
+    for collection in collections:
+        merged.extend(collection)
+    return sorted(merged, key=lambda row: row.measured_at)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -5,7 +5,7 @@ import sqlite3
 from pathlib import Path
 import streamlit as st
 
-from agents import analytics, data_ingestion
+from agents import ChatAgent, analytics, data_ingestion
 
 
 st.set_page_config(page_title="Lab Dashboard", layout="wide")
@@ -50,9 +50,8 @@ for r in results:
     )
 
 st.subheader("Chat with assistant")
+agent = ChatAgent(results)
 query = st.text_input("Ask a question about the data:")
 if query:
-    st.write(
-        "This demo does not connect to a real language model, but a future "
-        "implementation could route this query to an LLM-powered agent."
-    )
+    response = agent.answer(query)
+    st.write(response)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,57 +1,129 @@
-"""Simple Streamlit dashboard showcasing lab analytics and chat agent."""
+"""Professional Streamlit demo for an agentic laboratory operations dashboard."""
 from __future__ import annotations
 
+import io
 import sqlite3
-from pathlib import Path
+from typing import List
+
 import streamlit as st
 
 from agents import ChatAgent, analytics, data_ingestion
 
 
-st.set_page_config(page_title="Lab Dashboard", layout="wide")
-st.title("Laboratory Dashboard")
+st.set_page_config(page_title="AI Laboratory Command Center", layout="wide")
+st.title("🧪 AI Laboratory Command Center")
+st.caption("Agentic demo: multi-source ingestion, KPI analytics, alerting, and operations copilot.")
 
-# Sidebar data source selection
-source = st.sidebar.selectbox(
-    "Data source", ["Sample data", "CSV file", "SQLite DB"], index=0
+
+@st.cache_data(show_spinner=False)
+def _load_sample() -> List[data_ingestion.LabResult]:
+    return data_ingestion.load_sample_results()
+
+
+source_mode = st.sidebar.radio(
+    "Connection mode",
+    ["Sample", "CSV upload", "JSON upload", "SQLite query", "Multi-source merge"],
+    index=0,
 )
 
-results: list[data_ingestion.LabResult] = []
-if source == "Sample data":
-    results = data_ingestion.load_sample_results()
-elif source == "CSV file":
-    uploaded = st.sidebar.file_uploader("Upload CSV", type="csv")
+results: List[data_ingestion.LabResult] = []
+
+if source_mode == "Sample":
+    results = _load_sample()
+
+elif source_mode == "CSV upload":
+    uploaded = st.sidebar.file_uploader("Upload results.csv", type="csv")
     if uploaded:
-        results = data_ingestion.load_results_from_csv(uploaded)
-    else:
-        st.info("Upload a CSV file to load results")
-elif source == "SQLite DB":
+        text_stream = io.StringIO(uploaded.getvalue().decode("utf-8"))
+        results = data_ingestion.load_results_from_csv(text_stream)
+
+elif source_mode == "JSON upload":
+    uploaded = st.sidebar.file_uploader("Upload results.json", type="json")
+    if uploaded:
+        text_stream = io.StringIO(uploaded.getvalue().decode("utf-8"))
+        results = data_ingestion.load_results_from_json(text_stream)
+
+elif source_mode == "SQLite query":
     db_path = st.sidebar.text_input("SQLite database path")
-    if db_path and Path(db_path).exists():
+    default_query = (
+        "SELECT sample_id, test_name, value, passed, measured_at, source_system, technician "
+        "FROM results"
+    )
+    query = st.sidebar.text_area("SQL query", value=default_query, height=100)
+    if db_path:
         conn = sqlite3.connect(db_path)
         try:
-            results = data_ingestion.load_results_from_db(
-                conn, "SELECT sample_id, test_name, value, passed FROM results"
-            )
+            results = data_ingestion.load_results_from_db(conn, query)
+        except Exception as exc:  # pragma: no cover - streamlit display path
+            st.error(f"Unable to load data: {exc}")
         finally:
             conn.close()
+
+elif source_mode == "Multi-source merge":
+    st.sidebar.write("Merge built-in sample with optional CSV and JSON payloads.")
+    csv_upload = st.sidebar.file_uploader("Optional CSV", type="csv")
+    json_upload = st.sidebar.file_uploader("Optional JSON", type="json")
+
+    merged = [_load_sample()]
+    if csv_upload:
+        merged.append(data_ingestion.load_results_from_csv(io.StringIO(csv_upload.getvalue().decode("utf-8"))))
+    if json_upload:
+        merged.append(data_ingestion.load_results_from_json(io.StringIO(json_upload.getvalue().decode("utf-8"))))
+    results = data_ingestion.merge_results(*merged)
+
+metrics = analytics.compute_dashboard_metrics(results)
+alerts = analytics.detect_alerts(results)
+
+c1, c2, c3, c4 = st.columns(4)
+c1.metric("Total tests", metrics.total_tests)
+c2.metric("Pass rate", f"{metrics.pass_rate:.0%}")
+c3.metric("Failures", metrics.failed_tests)
+c4.metric("Source systems", metrics.unique_systems)
+
+st.subheader("🚨 Monitoring Alerts")
+for alert in alerts:
+    if "within expected" in alert.lower():
+        st.success(alert)
     else:
-        st.info("Enter path to a SQLite database containing a 'results' table")
+        st.warning(alert)
 
-pass_rate = analytics.compute_pass_fail_rate(results)
+tab_overview, tab_records, tab_copilot = st.tabs(["Overview", "Records", "Ops Copilot"])
 
-st.metric("Pass rate", f"{pass_rate:.0%}")
+with tab_overview:
+    st.markdown("#### Pass rate by test")
+    rate_map = analytics.pass_rate_by_test(results)
+    if rate_map:
+        st.bar_chart({"pass_rate": rate_map})
+    else:
+        st.info("No records available.")
 
-st.subheader("Results")
-for r in results:
-    st.write(
-        f"Sample {r.sample_id} – {r.test_name}: value={r.value} | "
-        f"{'PASS' if r.passed else 'FAIL'}"
-    )
+    st.markdown("#### Daily test volume")
+    trend = analytics.daily_volume(results)
+    if trend:
+        st.line_chart({"volume": trend})
+    else:
+        st.info("No records available.")
 
-st.subheader("Chat with assistant")
-agent = ChatAgent(results)
-query = st.text_input("Ask a question about the data:")
-if query:
-    response = agent.answer(query)
-    st.write(response)
+with tab_records:
+    st.markdown("#### Normalized result table")
+    table = [
+        {
+            "sample_id": r.sample_id,
+            "test_name": r.test_name,
+            "value": r.value,
+            "status": "PASS" if r.passed else "FAIL",
+            "measured_at_utc": r.measured_at.isoformat(),
+            "source_system": r.source_system,
+            "technician": r.technician,
+        }
+        for r in results
+    ]
+    st.dataframe(table, use_container_width=True)
+
+with tab_copilot:
+    st.markdown("#### Ask the operations copilot")
+    st.caption("Example: 'Give KPI summary', 'pass rate by test', 'daily volume trend', 'failed samples'.")
+    agent = ChatAgent(results)
+    query = st.text_input("Ask about current loaded records")
+    if query:
+        st.write(agent.answer(query))

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,58 @@
+"""Simple Streamlit dashboard showcasing lab analytics and chat agent."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+import streamlit as st
+
+from agents import analytics, data_ingestion
+
+
+st.set_page_config(page_title="Lab Dashboard", layout="wide")
+st.title("Laboratory Dashboard")
+
+# Sidebar data source selection
+source = st.sidebar.selectbox(
+    "Data source", ["Sample data", "CSV file", "SQLite DB"], index=0
+)
+
+results: list[data_ingestion.LabResult] = []
+if source == "Sample data":
+    results = data_ingestion.load_sample_results()
+elif source == "CSV file":
+    uploaded = st.sidebar.file_uploader("Upload CSV", type="csv")
+    if uploaded:
+        results = data_ingestion.load_results_from_csv(uploaded)
+    else:
+        st.info("Upload a CSV file to load results")
+elif source == "SQLite DB":
+    db_path = st.sidebar.text_input("SQLite database path")
+    if db_path and Path(db_path).exists():
+        conn = sqlite3.connect(db_path)
+        try:
+            results = data_ingestion.load_results_from_db(
+                conn, "SELECT sample_id, test_name, value, passed FROM results"
+            )
+        finally:
+            conn.close()
+    else:
+        st.info("Enter path to a SQLite database containing a 'results' table")
+
+pass_rate = analytics.compute_pass_fail_rate(results)
+
+st.metric("Pass rate", f"{pass_rate:.0%}")
+
+st.subheader("Results")
+for r in results:
+    st.write(
+        f"Sample {r.sample_id} – {r.test_name}: value={r.value} | "
+        f"{'PASS' if r.passed else 'FAIL'}"
+    )
+
+st.subheader("Chat with assistant")
+query = st.text_input("Ask a question about the data:")
+if query:
+    st.write(
+        "This demo does not connect to a real language model, but a future "
+        "implementation could route this query to an LLM-powered agent."
+    )

--- a/demo_run.py
+++ b/demo_run.py
@@ -1,0 +1,64 @@
+"""One-command demo runner for the AI laboratory dashboard."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict
+from typing import Any, Dict
+
+from agents import ChatAgent, analytics, data_ingestion
+
+
+def build_demo_report() -> Dict[str, Any]:
+    """Build a deterministic demo report from sample data."""
+
+    results = data_ingestion.load_sample_results()
+    metrics = analytics.compute_dashboard_metrics(results)
+    agent = ChatAgent(results)
+
+    return {
+        "metrics": asdict(metrics),
+        "pass_rate_by_test": analytics.pass_rate_by_test(results),
+        "daily_volume": analytics.daily_volume(results),
+        "alerts": analytics.detect_alerts(results),
+        "copilot_examples": {
+            "summary": agent.answer("Give KPI summary"),
+            "pass_rate_by_test": agent.answer("pass rate by test"),
+            "failed_samples": agent.answer("list failed samples"),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run lab dashboard demo checks.")
+    parser.add_argument(
+        "--launch-ui",
+        action="store_true",
+        help="Launch Streamlit UI after printing demo report.",
+    )
+    args = parser.parse_args()
+
+    report = build_demo_report()
+    print("=== Demo Report ===")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+    if args.launch_ui:
+        cmd = [
+            sys.executable,
+            "-m",
+            "streamlit",
+            "run",
+            "dashboard/app.py",
+            "--server.headless",
+            "true",
+        ]
+        print("\nLaunching Streamlit:", " ".join(cmd))
+        return subprocess.call(cmd)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit>=1.30

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -4,5 +4,17 @@ from agents import analytics, data_ingestion
 def test_compute_pass_fail_rate():
     results = data_ingestion.load_sample_results()
     rate = analytics.compute_pass_fail_rate(results)
-    # There are two passing results out of four total
-    assert rate == 0.5
+    assert rate == 0.625
+
+
+def test_compute_dashboard_metrics():
+    metrics = analytics.compute_dashboard_metrics(data_ingestion.load_sample_results())
+    assert metrics.total_tests == 8
+    assert metrics.passed_tests == 5
+    assert metrics.failed_tests == 3
+    assert metrics.unique_systems == 3
+
+
+def test_detect_alerts_when_threshold_low():
+    alerts = analytics.detect_alerts(data_ingestion.load_sample_results(), fail_rate_threshold=0.2)
+    assert any("High failure rate" in item for item in alerts)

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,8 @@
+from agents import analytics, data_ingestion
+
+
+def test_compute_pass_fail_rate():
+    results = data_ingestion.load_sample_results()
+    rate = analytics.compute_pass_fail_rate(results)
+    # There are two passing results out of four total
+    assert rate == 0.5

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -7,7 +7,14 @@ def test_chat_agent_pass_rate():
     results = data_ingestion.load_sample_results()
     agent = ChatAgent(results)
     response = agent.answer("What is the pass rate?")
-    assert "50%" in response
+    assert "62%" in response
+
+
+def test_chat_agent_summary():
+    results = data_ingestion.load_sample_results()
+    agent = ChatAgent(results)
+    response = agent.answer("Give KPI summary")
+    assert "Processed 8 tests" in response
 
 
 def test_chat_agent_unknown_query():
@@ -15,4 +22,3 @@ def test_chat_agent_unknown_query():
     agent = ChatAgent(results)
     response = agent.answer("How many unicorns?")
     assert "pass rate" in response.lower()
-

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -1,0 +1,18 @@
+"""Tests for the simple chat agent."""
+
+from agents import ChatAgent, data_ingestion
+
+
+def test_chat_agent_pass_rate():
+    results = data_ingestion.load_sample_results()
+    agent = ChatAgent(results)
+    response = agent.answer("What is the pass rate?")
+    assert "50%" in response
+
+
+def test_chat_agent_unknown_query():
+    results = data_ingestion.load_sample_results()
+    agent = ChatAgent(results)
+    response = agent.answer("How many unicorns?")
+    assert "pass rate" in response.lower()
+

--- a/tests/test_data_ingestion.py
+++ b/tests/test_data_ingestion.py
@@ -1,5 +1,7 @@
 """Tests for data ingestion helpers."""
 import csv
+import io
+import json
 import sqlite3
 
 from agents import data_ingestion
@@ -9,7 +11,16 @@ def test_load_results_from_csv(tmp_path):
     csv_path = tmp_path / "results.csv"
     with open(csv_path, "w", newline="") as fh:
         writer = csv.DictWriter(
-            fh, fieldnames=["sample_id", "test_name", "value", "passed"]
+            fh,
+            fieldnames=[
+                "sample_id",
+                "test_name",
+                "value",
+                "passed",
+                "measured_at",
+                "source_system",
+                "technician",
+            ],
         )
         writer.writeheader()
         writer.writerow(
@@ -18,29 +29,55 @@ def test_load_results_from_csv(tmp_path):
                 "test_name": "PCR",
                 "value": "1.0",
                 "passed": "1",
+                "measured_at": "2026-04-01T00:00:00Z",
+                "source_system": "CSV-LIMS",
+                "technician": "Tech",
             }
         )
 
     results = data_ingestion.load_results_from_csv(csv_path)
-    assert results == [
-        data_ingestion.LabResult("S1", "PCR", 1.0, True)
-    ]
+    assert len(results) == 1
+    assert results[0].source_system == "CSV-LIMS"
+
+
+def test_load_results_from_json():
+    payload = io.StringIO(
+        json.dumps(
+            [
+                {
+                    "sample_id": "S2",
+                    "test_name": "CBC",
+                    "value": 2.5,
+                    "passed": "true",
+                    "source_system": "JSON-LIMS",
+                }
+            ]
+        )
+    )
+    results = data_ingestion.load_results_from_json(payload)
+    assert results[0].passed is True
 
 
 def test_load_results_from_db():
     conn = sqlite3.connect(":memory:")
     conn.execute(
-        "CREATE TABLE results (sample_id TEXT, test_name TEXT, value REAL, passed INTEGER)"
+        "CREATE TABLE results (sample_id TEXT, test_name TEXT, value REAL, passed INTEGER, measured_at TEXT, source_system TEXT, technician TEXT)"
     )
     conn.execute(
-        "INSERT INTO results VALUES ('S1', 'PCR', 1.0, 1)"
+        "INSERT INTO results VALUES ('S1', 'PCR', 1.0, 1, '2026-04-01T00:00:00Z', 'DB-LIMS', 'Tech')"
     )
     conn.commit()
 
     results = data_ingestion.load_results_from_db(
-        conn, "SELECT sample_id, test_name, value, passed FROM results"
+        conn,
+        "SELECT sample_id, test_name, value, passed, measured_at, source_system, technician FROM results",
     )
     conn.close()
 
-    assert results == [data_ingestion.LabResult("S1", "PCR", 1.0, True)]
+    assert results[0].source_system == "DB-LIMS"
 
+
+def test_merge_results_keeps_chronological_order():
+    sample = data_ingestion.load_sample_results()
+    merged = data_ingestion.merge_results(sample[4:], sample[:4])
+    assert merged[0].measured_at <= merged[-1].measured_at

--- a/tests/test_data_ingestion.py
+++ b/tests/test_data_ingestion.py
@@ -1,0 +1,46 @@
+"""Tests for data ingestion helpers."""
+import csv
+import sqlite3
+
+from agents import data_ingestion
+
+
+def test_load_results_from_csv(tmp_path):
+    csv_path = tmp_path / "results.csv"
+    with open(csv_path, "w", newline="") as fh:
+        writer = csv.DictWriter(
+            fh, fieldnames=["sample_id", "test_name", "value", "passed"]
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "sample_id": "S1",
+                "test_name": "PCR",
+                "value": "1.0",
+                "passed": "1",
+            }
+        )
+
+    results = data_ingestion.load_results_from_csv(csv_path)
+    assert results == [
+        data_ingestion.LabResult("S1", "PCR", 1.0, True)
+    ]
+
+
+def test_load_results_from_db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE results (sample_id TEXT, test_name TEXT, value REAL, passed INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO results VALUES ('S1', 'PCR', 1.0, 1)"
+    )
+    conn.commit()
+
+    results = data_ingestion.load_results_from_db(
+        conn, "SELECT sample_id, test_name, value, passed FROM results"
+    )
+    conn.close()
+
+    assert results == [data_ingestion.LabResult("S1", "PCR", 1.0, True)]
+

--- a/tests/test_demo_run.py
+++ b/tests/test_demo_run.py
@@ -1,0 +1,9 @@
+from demo_run import build_demo_report
+
+
+def test_build_demo_report_shape():
+    report = build_demo_report()
+    assert report["metrics"]["total_tests"] == 8
+    assert "pass_rate_by_test" in report
+    assert "copilot_examples" in report
+    assert "summary" in report["copilot_examples"]


### PR DESCRIPTION
## Summary
- scaffold `agents` package with sample data ingestion and analytics utilities
- add Streamlit dashboard displaying pass rate and sample results
- include unit test for analytics calculations and usage guide in README
- support loading lab results from CSV files and DB connections with dashboard source selector

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac319593488321853143c9250a48f4